### PR TITLE
mkcurl.hpp: rename static functions

### DIFF
--- a/mkcurl.hpp
+++ b/mkcurl.hpp
@@ -182,7 +182,7 @@ struct mkcurl_slist {
 
 extern "C" {
 
-static size_t mkcurl_body_cb(
+static size_t mkcurl_body_cb_(
     char *ptr, size_t size, size_t nmemb, void *userdata) {
   if (nmemb <= 0) {
     return 0;  // This means "no body"
@@ -203,7 +203,7 @@ static size_t mkcurl_body_cb(
   return nmemb;
 }
 
-static int mkcurl_debug_cb(CURL *handle,
+static int mkcurl_debug_cb_(CURL *handle,
                            curl_infotype type,
                            char *data,
                            size_t size,
@@ -478,7 +478,7 @@ Response perform(const Request &req) noexcept {
   }
   {
     res.error = curl_easy_setopt(handle.get(), CURLOPT_WRITEFUNCTION,
-                                 mkcurl_body_cb);
+                                 mkcurl_body_cb_);
     MKCURL_HOOK(curl_easy_setopt_CURLOPT_WRITEFUNCTION, res.error);
     if (res.error != CURLE_OK) {
       mkcurl_log(res.logs, "curl_easy_setopt(CURLOPT_WRITEFUNCTION) failed");
@@ -525,7 +525,7 @@ Response perform(const Request &req) noexcept {
   }
   {
     res.error = curl_easy_setopt(handle.get(), CURLOPT_DEBUGFUNCTION,
-                                 mkcurl_debug_cb);
+                                 mkcurl_debug_cb_);
     MKCURL_HOOK(curl_easy_setopt_CURLOPT_DEBUGFUNCTION, res.error);
     if (res.error != CURLE_OK) {
       mkcurl_log(res.logs, "curl_easy_setopt(CURLOPT_DEBUGFUNCTION) failed");

--- a/mkcurl.hpp
+++ b/mkcurl.hpp
@@ -232,22 +232,26 @@ static int mkcurl_debug_cb_(CURL *handle,
     case CURLINFO_TEXT:
       log_many_lines("", std::string{(const char *)data, size});
       break;
-    case CURLINFO_HEADER_IN: {
-      std::string s{(const char *)data, size};
-      log_many_lines("<", s);
-      res->response_headers += s;
-    } break;
+    case CURLINFO_HEADER_IN:
+      {
+        std::string s{(const char *)data, size};
+        log_many_lines("<", s);
+        res->response_headers += s;
+      }
+      break;
     case CURLINFO_DATA_IN:
       log_many_lines("<data:", std::to_string(size));
       break;
     case CURLINFO_SSL_DATA_IN:
       log_many_lines("<tls_data:", std::to_string(size));
       break;
-    case CURLINFO_HEADER_OUT: {
-      std::string s{(const char *)data, size};
-      log_many_lines(">", s);
-      res->request_headers += s;
-    } break;
+    case CURLINFO_HEADER_OUT:
+      {
+        std::string s{(const char *)data, size};
+        log_many_lines(">", s);
+        res->request_headers += s;
+      }
+      break;
     case CURLINFO_DATA_OUT:
       log_many_lines(">data:", std::to_string(size));
       break;

--- a/mkcurl.hpp
+++ b/mkcurl.hpp
@@ -115,8 +115,8 @@ Response perform(const Request &request) noexcept;
 #include <assert.h>
 
 #include <algorithm>
-#include <memory>
 #include <chrono>
+#include <memory>
 #include <sstream>
 
 #include <curl/curl.h>
@@ -204,10 +204,10 @@ static size_t mkcurl_body_cb_(
 }
 
 static int mkcurl_debug_cb_(CURL *handle,
-                           curl_infotype type,
-                           char *data,
-                           size_t size,
-                           void *userptr) {
+                            curl_infotype type,
+                            char *data,
+                            size_t size,
+                            void *userptr) {
   (void)handle;
   if (data == nullptr || userptr == nullptr) {
     MKCURL_ABORT();
@@ -232,26 +232,22 @@ static int mkcurl_debug_cb_(CURL *handle,
     case CURLINFO_TEXT:
       log_many_lines("", std::string{(const char *)data, size});
       break;
-    case CURLINFO_HEADER_IN:
-      {
-        std::string s{(const char *)data, size};
-        log_many_lines("<", s);
-        res->response_headers += s;
-      }
-      break;
+    case CURLINFO_HEADER_IN: {
+      std::string s{(const char *)data, size};
+      log_many_lines("<", s);
+      res->response_headers += s;
+    } break;
     case CURLINFO_DATA_IN:
       log_many_lines("<data:", std::to_string(size));
       break;
     case CURLINFO_SSL_DATA_IN:
       log_many_lines("<tls_data:", std::to_string(size));
       break;
-    case CURLINFO_HEADER_OUT:
-      {
-        std::string s{(const char *)data, size};
-        log_many_lines(">", s);
-        res->request_headers += s;
-      }
-      break;
+    case CURLINFO_HEADER_OUT: {
+      std::string s{(const char *)data, size};
+      log_many_lines(">", s);
+      res->request_headers += s;
+    } break;
     case CURLINFO_DATA_OUT:
       log_many_lines(">data:", std::to_string(size));
       break;

--- a/tests.cpp
+++ b/tests.cpp
@@ -68,38 +68,38 @@ MKMOCK_DEFINE_HOOK(curl_easy_getinfo_CURLINFO_HTTP_VERSION, CURLcode);
 // Unit tests
 // ----------
 
-TEST_CASE("When mkcurl_body_cb is passed zero nmemb") {
-  REQUIRE(mkcurl_body_cb(nullptr, 17, 0, nullptr) == 0);
+TEST_CASE("When mkcurl_body_cb_ is passed zero nmemb") {
+  REQUIRE(mkcurl_body_cb_(nullptr, 17, 0, nullptr) == 0);
 }
 
-TEST_CASE("When mkcurl_body_cb would overflow a size_t") {
-  REQUIRE(mkcurl_body_cb(nullptr, SIZE_MAX / 2, 4, nullptr) == 0);
+TEST_CASE("When mkcurl_body_cb_ would overflow a size_t") {
+  REQUIRE(mkcurl_body_cb_(nullptr, SIZE_MAX / 2, 4, nullptr) == 0);
 }
 
-TEST_CASE("When mkcurl_body_cb is passed a NULL ptr") {
-  REQUIRE_THROWS(mkcurl_body_cb(nullptr, 17, 4, (void *)0x123456));
+TEST_CASE("When mkcurl_body_cb_ is passed a NULL ptr") {
+  REQUIRE_THROWS(mkcurl_body_cb_(nullptr, 17, 4, (void *)0x123456));
 }
 
-TEST_CASE("When mkcurl_body_cb is passed a NULL userdata") {
-  REQUIRE_THROWS(mkcurl_body_cb((char *)0x123456, 17, 4, nullptr));
+TEST_CASE("When mkcurl_body_cb_ is passed a NULL userdata") {
+  REQUIRE_THROWS(mkcurl_body_cb_((char *)0x123456, 17, 4, nullptr));
 }
 
-TEST_CASE("When mkcurl_debug_cb is passed a NULL data") {
-  REQUIRE_THROWS(mkcurl_debug_cb(nullptr, CURLINFO_TEXT, nullptr, 0,
+TEST_CASE("When mkcurl_debug_cb_ is passed a NULL data") {
+  REQUIRE_THROWS(mkcurl_debug_cb_(nullptr, CURLINFO_TEXT, nullptr, 0,
                                  (void *)0x123456));
 }
 
-TEST_CASE("When mkcurl_debug_cb is passed a NULL userptr") {
-  REQUIRE_THROWS(mkcurl_debug_cb(nullptr, CURLINFO_TEXT, (char *)0x123456,
+TEST_CASE("When mkcurl_debug_cb_ is passed a NULL userptr") {
+  REQUIRE_THROWS(mkcurl_debug_cb_(nullptr, CURLINFO_TEXT, (char *)0x123456,
                                  0, nullptr));
 }
 
-TEST_CASE("When mkcurl_debug_cb is passed a unexpected curl_infotype") {
+TEST_CASE("When mkcurl_debug_cb_ is passed a unexpected curl_infotype") {
   // Implementation note: here the return value doesn't matter much; what
   // really matters is that the code does not misbehave.
   mk::curl::Response resp;
   std::string data;
-  REQUIRE(mkcurl_debug_cb(nullptr, CURLINFO_END, (char *)data.c_str(),
+  REQUIRE(mkcurl_debug_cb_(nullptr, CURLINFO_END, (char *)data.c_str(),
                           data.size(), &resp) == 0);
 }
 


### PR DESCRIPTION
This should allow to compile this version of mkcurl along with
the previous version that had a pure C API as part of MK.