### PR TITLE
mkcurl.hpp: inline namespace for public symbols

### DIFF
--- a/MKBuild.yaml
+++ b/MKBuild.yaml
@@ -1,6 +1,7 @@
 name: mkcurl
 
 docker: bassosimone/mk-debian
+docker_tc_disabled: true
 
 dependencies:
 - github.com/adishavit/argh

--- a/mkcurl.hpp
+++ b/mkcurl.hpp
@@ -686,6 +686,9 @@ static Response perform2(mkcurl_uptr &handle, const Request &req) noexcept {
   {
     res.error = perform_and_retry(handle.get(), req.retries, res.logs);
     if (res.error != CURLE_OK) {
+      std::stringstream ss;
+      ss << "curl_easy_perform: " << curl_easy_strerror((CURLcode)res.error);
+      mkcurl_log(res.logs, ss.str());
       return res;
     }
   }

--- a/mkcurl.hpp
+++ b/mkcurl.hpp
@@ -10,8 +10,15 @@
 #include <string>
 #include <vector>
 
+/// MKCURL_INLINE_NAMESPACE controls the inline inner namespace in which
+/// public symbols exported by this library are enclosed.
+///
+/// See <https://github.com/measurement-kit/measurement-kit/issues/1867#issuecomment-514562622>.
+#define MKCURL_INLINE_NAMESPACE v0_11_2_or_greater
+
 namespace mk {
 namespace curl {
+inline namespace MKCURL_INLINE_NAMESPACE {
 
 /// Request is an HTTP request.
 struct Request {
@@ -154,6 +161,7 @@ class Client {
 /// perform performs @p request and returns the Response.
 Response perform(const Request &request) noexcept;
 
+}  // inline namespace MKCURL_INLINE_NAMESPACE
 }  // namespace curl
 }  // namespace mk
 
@@ -188,6 +196,7 @@ Response perform(const Request &request) noexcept;
 
 namespace mk {
 namespace curl {
+inline namespace MKCURL_INLINE_NAMESPACE {
 
 // mkcurl_log appends @p line to @p logs. It adds information on the current
 // time in millisecond. It also appends a newline to the end of the line.
@@ -239,6 +248,7 @@ struct mkcurl_slist {
   curl_slist *p = nullptr;
 };
 
+}  // inline namespace MKCURL_INLINE_NAMESPACE
 }  // namespace curl
 }  // namespace mk
 
@@ -374,6 +384,7 @@ static int mkcurl_debug_cb_(CURL *handle,
 
 namespace mk {
 namespace curl {
+inline namespace MKCURL_INLINE_NAMESPACE {
 
 // HTTPVersionString returns a string representation of the cURL HTTP
 // version string in @p httpv. If @p httpv has an unknown value, the
@@ -757,6 +768,7 @@ Response perform(const Request &req) noexcept {
   return Client{}.perform(req);
 }
 
+}  // inline namespace MKCURL_INLINE_NAMESPACE
 }  // namespace curl
 }  // namespace mk
 #endif  // MKCURL_INLINE_IMPL


### PR DESCRIPTION
This allows us to have more than one version of mkcurl inside of
android-libs and/or mkall-ios for testing pursposes. Currently mkcurl
is part of MK, so testing is much slower then that as we need to
vendor mkcurl into MK, do a full build of MK, and the use that with
the apps. With this change, we can be quicker because we can vendor
the new version of mkcurl and test it out directly. If that's OK
then we can go for vendoring into MK and doing a full build.

Xref: https://github.com/measurement-kit/measurement-kit/issues/1867

See also: https://github.com/measurement-kit/mkcollector/pull/25#discussion_r305323787